### PR TITLE
Add ARM aarch64 support to CPU implementation

### DIFF
--- a/cpu/ext/ffmpeg-svt/CMakeLists.txt
+++ b/cpu/ext/ffmpeg-svt/CMakeLists.txt
@@ -18,8 +18,10 @@ endif()
 
 option(BUILD_GPL_X264 "Build X264 with GPL License" OFF)
 
-set(SVTHEVCENC_LIB ${VPL_DEP_DIR}/lib/libSvtHevcEnc.a)
-set(SVTAV1ENC_LIB ${VPL_DEP_DIR}/lib/libSvtAv1Enc.a)
+if(BUILD_SVT)
+  set(SVTHEVCENC_LIB ${VPL_DEP_DIR}/lib/libSvtHevcEnc.a)
+  set(SVTAV1ENC_LIB ${VPL_DEP_DIR}/lib/libSvtAv1Enc.a)
+endif()
 set(DAV1D_LIB ${VPL_DEP_DIR}/lib/libdav1d.a)
 set(AVCODEC_LIB ${VPL_DEP_DIR}/lib/libavcodec.a)
 set(AVUTIL_LIB ${VPL_DEP_DIR}/lib/libavutil.a)
@@ -33,9 +35,14 @@ if(BUILD_GPL_X264)
   endif()
 endif(BUILD_GPL_X264)
 
-if(NOT EXISTS ${SVTHEVCENC_LIB}
-   OR NOT EXISTS ${SVTHEVCENC_LIB}
-   OR NOT EXISTS ${DAV1D_LIB}
+if(BUILD_SVT)
+  if(NOT EXISTS ${SVTHEVCENC_LIB}
+     OR NOT EXISTS ${SVTHEVCENC_LIB})
+    message(FATAL_ERROR "Could not find expected SVT libraries")
+  endif()
+endif()
+
+if(NOT EXISTS ${DAV1D_LIB}
    OR NOT EXISTS ${AVCODEC_LIB}
    OR NOT EXISTS ${AVUTIL_LIB}
    OR NOT EXISTS ${AVFILTER_LIB}

--- a/docker/Dockerfile-centos-7
+++ b/docker/Dockerfile-centos-7
@@ -72,12 +72,8 @@ RUN cp -r /oneVPL/_deps/lib64/* /oneVPL/_deps/lib
 ARG VPL_BUILD_DEPENDENCIES=/oneVPL/_deps
 ARG VPL_INSTALL_PREFIX
 RUN cd /oneVPL && \
-    mkdir _build && \
-    cd _build && \
-    source /opt/rh/devtoolset-7/enable && \
-    cmake -DCMAKE_INSTALL_PREFIX=${VPL_INSTALL_PREFIX} .. && \
-    make -j $(nproc --all) && \
-    make install
+  script/build && \
+  script/install
 
 
 # Runtime image build

--- a/docker/Dockerfile-centos-7-GPL
+++ b/docker/Dockerfile-centos-7-GPL
@@ -72,12 +72,8 @@ RUN cp -r /oneVPL/_deps/lib64/* /oneVPL/_deps/lib
 ARG VPL_BUILD_DEPENDENCIES=/oneVPL/_deps
 ARG VPL_INSTALL_PREFIX
 RUN cd /oneVPL && \
-    mkdir _build && \
-    cd _build && \
-    source /opt/rh/devtoolset-7/enable && \
-    cmake -DBUILD_GPL_X264=ON -DCMAKE_INSTALL_PREFIX=${VPL_INSTALL_PREFIX} .. && \
-    make -j $(nproc --all) && \
-    make install
+  script/build gpl && \
+  script/install
 
 
 # Runtime image build

--- a/docker/Dockerfile-centos-8
+++ b/docker/Dockerfile-centos-8
@@ -52,11 +52,8 @@ RUN cp -r /oneVPL/_deps/lib64/* /oneVPL/_deps/lib
 ARG VPL_BUILD_DEPENDENCIES=/oneVPL/_deps
 ARG VPL_INSTALL_PREFIX
 RUN cd /oneVPL && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DCMAKE_INSTALL_PREFIX=${VPL_INSTALL_PREFIX} .. && \
-    make -j $(nproc --all) && \
-    make install
+  script/build && \
+  script/install
 
 
 # Runtime image build

--- a/docker/Dockerfile-ubuntu-18.04
+++ b/docker/Dockerfile-ubuntu-18.04
@@ -45,11 +45,8 @@ COPY --from=vpl_bootstrap /oneVPL/_deps /oneVPL/_deps
 ARG VPL_BUILD_DEPENDENCIES=/oneVPL/_deps
 ARG VPL_INSTALL_PREFIX
 RUN cd /oneVPL && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DCMAKE_INSTALL_PREFIX=${VPL_INSTALL_PREFIX} .. && \
-    make -j $(nproc --all) && \
-    make install
+  script/build && \
+  script/install
 
 
 # Runtime image build

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -45,12 +45,8 @@ COPY --from=vpl_bootstrap /oneVPL/_deps /oneVPL/_deps
 ARG VPL_BUILD_DEPENDENCIES=/oneVPL/_deps
 ARG VPL_INSTALL_PREFIX
 RUN cd /oneVPL && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DCMAKE_INSTALL_PREFIX=${VPL_INSTALL_PREFIX} .. && \
-    make -j $(nproc --all) && \
-    make install
-
+  script/build && \
+  script/install
 
 # Runtime image build
 FROM ubuntu:20.04 

--- a/docker/build_docker_images.sh
+++ b/docker/build_docker_images.sh
@@ -7,10 +7,10 @@
 
 set -e
 BASEDIR=$(dirname "$0")
-#docker build -f ${BASEDIR}/Dockerfile-centos-7-GPL -t vpl-cpu:centos7-GPL ${BASEDIR}/..
-#docker build -f ${BASEDIR}/Dockerfile-centos-7     -t vpl-cpu:centos7     ${BASEDIR}/..
-#docker build -f ${BASEDIR}/Dockerfile-centos-8     -t vpl-cpu:centos8     ${BASEDIR}/..
-#docker build -f ${BASEDIR}/Dockerfile-ubuntu-18.04 -t vpl-cpu:ubuntu18.04 ${BASEDIR}/..
+docker build -f ${BASEDIR}/Dockerfile-centos-7-GPL -t vpl-cpu:centos7-GPL ${BASEDIR}/..
+docker build -f ${BASEDIR}/Dockerfile-centos-7     -t vpl-cpu:centos7     ${BASEDIR}/..
+docker build -f ${BASEDIR}/Dockerfile-centos-8     -t vpl-cpu:centos8     ${BASEDIR}/..
+docker build -f ${BASEDIR}/Dockerfile-ubuntu-18.04 -t vpl-cpu:ubuntu18.04 ${BASEDIR}/..
 
 if [ "$(uname -m)" == "x86_64" ]; then
 	docker build -f ${BASEDIR}/Dockerfile-ubuntu-19.10 -t vpl-cpu:ubuntu19.10 ${BASEDIR}/..

--- a/docker/build_docker_images.sh
+++ b/docker/build_docker_images.sh
@@ -7,9 +7,13 @@
 
 set -e
 BASEDIR=$(dirname "$0")
-docker build -f ${BASEDIR}/Dockerfile-centos-7-GPL -t vpl-cpu:centos7-GPL ${BASEDIR}/..
-docker build -f ${BASEDIR}/Dockerfile-centos-7     -t vpl-cpu:centos7     ${BASEDIR}/..
-docker build -f ${BASEDIR}/Dockerfile-centos-8     -t vpl-cpu:centos8     ${BASEDIR}/..
-docker build -f ${BASEDIR}/Dockerfile-ubuntu-18.04 -t vpl-cpu:ubuntu18.04 ${BASEDIR}/..
-docker build -f ${BASEDIR}/Dockerfile-ubuntu-19.10 -t vpl-cpu:ubuntu19.10 ${BASEDIR}/..
+#docker build -f ${BASEDIR}/Dockerfile-centos-7-GPL -t vpl-cpu:centos7-GPL ${BASEDIR}/..
+#docker build -f ${BASEDIR}/Dockerfile-centos-7     -t vpl-cpu:centos7     ${BASEDIR}/..
+#docker build -f ${BASEDIR}/Dockerfile-centos-8     -t vpl-cpu:centos8     ${BASEDIR}/..
+#docker build -f ${BASEDIR}/Dockerfile-ubuntu-18.04 -t vpl-cpu:ubuntu18.04 ${BASEDIR}/..
+
+if [ "$(uname -m)" == "x86_64" ]; then
+	docker build -f ${BASEDIR}/Dockerfile-ubuntu-19.10 -t vpl-cpu:ubuntu19.10 ${BASEDIR}/..
+fi
+
 docker build -f ${BASEDIR}/Dockerfile-ubuntu-20.04 -t vpl-cpu:ubuntu20.04 ${BASEDIR}/..

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -55,28 +55,31 @@ rm -rf ${VPL_BUILD_DEPENDENCIES}
 ## build FFmpeg with SVT-HEVC & SVT-AV1
 mkdir -p ${build_dir}
 cd ${build_dir}
-git clone --depth=1 -b v1.5.0 https://github.com/OpenVisualCloud/SVT-HEVC.git && cd SVT-HEVC
-sed -i 's/#define LIB_PRINTF_ENABLE                1/#define LIB_PRINTF_ENABLE                0/' \
-      ./Source/Lib/Codec/EbDefinitions.h
-if [ "$BUILD_MODE" == "Debug" ]; then
-  sed -i 's/#define DEBUG_MEMORY_USAGE/#undef DEBUG_MEMORY_USAGE/' \
-        ./Source/Lib/Codec/EbMalloc.h
-fi
-mkdir release && cd release
-cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_MODE} \
-      -DCMAKE_INSTALL_PREFIX=${install_dir}/ -DBUILD_SHARED_LIBS=off -DBUILD_APP=off
-make -j $(nproc) && make install
 
-cd ${build_dir}
-git clone --depth=1 -b v0.8.4 https://github.com/AOMediaCodec/SVT-AV1 && cd SVT-AV1
-if [ "$BUILD_MODE" == "Debug" ]; then
-  sed -i 's/#define DEBUG_MEMORY_USAGE/#undef DEBUG_MEMORY_USAGE/' \
-        ./Source/Lib/Common/Codec/EbMalloc.h
+if [ "$(uname -m)" == "x86_64" ]; then
+    git clone --depth=1 -b v1.5.0 https://github.com/OpenVisualCloud/SVT-HEVC.git && cd SVT-HEVC
+    sed -i 's/#define LIB_PRINTF_ENABLE                1/#define LIB_PRINTF_ENABLE                0/' \
+          ./Source/Lib/Codec/EbDefinitions.h
+    if [ "$BUILD_MODE" == "Debug" ]; then
+      sed -i 's/#define DEBUG_MEMORY_USAGE/#undef DEBUG_MEMORY_USAGE/' \
+            ./Source/Lib/Codec/EbMalloc.h
+    fi
+    mkdir release && cd release
+    cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_MODE} \
+          -DCMAKE_INSTALL_PREFIX=${install_dir}/ -DBUILD_SHARED_LIBS=off -DBUILD_APP=off
+    make -j $(nproc) && make install
+
+    cd ${build_dir}
+    git clone --depth=1 -b v0.8.4 https://github.com/AOMediaCodec/SVT-AV1 && cd SVT-AV1
+    if [ "$BUILD_MODE" == "Debug" ]; then
+      sed -i 's/#define DEBUG_MEMORY_USAGE/#undef DEBUG_MEMORY_USAGE/' \
+            ./Source/Lib/Common/Codec/EbMalloc.h
+    fi
+    mkdir release && cd release
+    cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_MODE} \
+          -DCMAKE_INSTALL_PREFIX=${install_dir}/ -DBUILD_SHARED_LIBS=off -DBUILD_APPS=off -DCMAKE_C_FLAGS="$(CMAKE_C_FLAGS) -DSVT_LOG_QUIET=1"
+    make -j $(nproc) && make install
 fi
-mkdir release && cd release
-cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=${BUILD_MODE} \
-      -DCMAKE_INSTALL_PREFIX=${install_dir}/ -DBUILD_SHARED_LIBS=off -DBUILD_APPS=off -DCMAKE_C_FLAGS="$(CMAKE_C_FLAGS) -DSVT_LOG_QUIET=1"
-make -j $(nproc) && make install
 
 if [ "$USE_GPL" == "yes" ]; then
   ## build x264
@@ -99,12 +102,18 @@ ninja install
 cd ${build_dir}
 git clone --depth=1 -b n4.3.1 https://github.com/FFmpeg/FFmpeg ffmpeg && cd ffmpeg
 
-git config user.email "bootstrap@localhost"
-git config user.name "bootstrap"
-patch=0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
-git am ${build_dir}/SVT-HEVC/ffmpeg_plugin/${patch}
-patch=0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
-git am ${build_dir}/SVT-AV1/ffmpeg_plugin/${patch}
+if [ "$(uname -m)" == "x86_64" ]; then
+    git config user.email "bootstrap@localhost"
+    git config user.name "bootstrap"
+    patch=0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+    git am ${build_dir}/SVT-HEVC/ffmpeg_plugin/${patch}
+    patch=0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+    git am ${build_dir}/SVT-AV1/ffmpeg_plugin/${patch}
+
+    enable_svt_options='--enable-libsvthevc --enable-encoder=libsvt_hevc --enable-libsvtav1 --enable-encoder=libsvt_av1'
+else
+    enable_svt_options=''
+fi
 
 sed -i 's/OBJS-$(CONFIG_TESTSRC2_FILTER)               += vsrc_testsrc.o/OBJS-$(CONFIG_TESTSRC2_FILTER)               += vsrc_testsrc.o ..\/libavutil\/xga_font_data.o/' \
       ./libavfilter/Makefile
@@ -195,10 +204,7 @@ fi
             --enable-filter=ssim  \
             --enable-filter=select \
             --enable-filter=concat \
-            --enable-libsvthevc \
-            --enable-encoder=libsvt_hevc \
-            --enable-libsvtav1 \
-            --enable-encoder=libsvt_av1 \
+            ${enable_svt_options} \
             --enable-libdav1d \
             --enable-decoder=libdav1d
 

--- a/script/build
+++ b/script/build
@@ -35,10 +35,14 @@ if [ "${USE_GPL}" == "yes" ]; then
  GPL_OPTS=-DBUILD_GPL_X264=ON
 fi
 
+if [ "$(uname -m)" == "x86_64" ]; then
+  SVT_OPTS=-DBUILD_SVT=on
+fi
+
 mkdir -p ${CMAKE_BINARY_DIR}
 cd ${CMAKE_BINARY_DIR}
 
-cmake ${INSTALL_OPTS} ${GPL_OPTS} -DCMAKE_BUILD_TYPE=${BUILD_MODE} ..
+cmake ${INSTALL_OPTS} ${GPL_OPTS} ${SVT_OPTS} -DCMAKE_BUILD_TYPE=${BUILD_MODE} ..
 
 make -j $(nproc)
 


### PR DESCRIPTION
Signed-off-by: William Dean <wd13384@gmail.com>

Tested on Apple M1 with oneVPL provided docker files (except Ubuntu 19.10, which does not appear to support aarch64 in docker hub).  SvtHevc and SvcAv1 appear to be x86-64 only, so this PR enables aarch64 build by excluding them from script/build.  Fixed mistake in docker files that were not using script/build to generate library.